### PR TITLE
Backward compatible fix error on Nokogiri >=1.6.6.1

### DIFF
--- a/lib/twemoji.rb
+++ b/lib/twemoji.rb
@@ -131,7 +131,7 @@ module Twemoji
     # @return [Nokogiri::HTML::DocumentFragment] Parsed document.
     # @private
     def self.parse_document(doc)
-      doc.search('text()').each do |node|
+      doc.xpath('.//text() | text()').each do |node|
         content = node.to_html
         next if !content.include?(":")
         next if has_ancestor?(node, %w(pre code tt))


### PR DESCRIPTION
```
Nokogiri::XML::XPath::SyntaxError: Invalid expression: .//child::text() | self::child::text()
```