### PR TITLE
Restrict nokogiri to specific version ranges.

### DIFF
--- a/twemoji.gemspec
+++ b/twemoji.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = %w(lib)
 
-  spec.add_dependency "nokogiri", "~> 1.6"
+  spec.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
 end


### PR DESCRIPTION
nokogiri 1.6.x is buggy => sparklemotion/nokogiri#1233

Until the bug is fixed, define a range of working nokogiri gems.

closes #2 