### PR TITLE
fix erb example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ end
 In your ERb view:
 
 ```erb
-<%= emojify "I like chocolate :heart_eyes:!", image_size: "36x36 %>"
+<%= emojify "I like chocolate :heart_eyes:!", image_size: "36x36" %>
 ```
 
 will render


### PR DESCRIPTION
The quote being in the wrong place created a syntax error. 