### PR TITLE
Soften nokogiri dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Soften Nokogiri dependency to ~> 1.6.2 (>= 1.6.2, < 1.7) [#19](https://github.com/jollygoodcode/twemoji/pull/19)
+
 ## 2.0.0 - 2015.05.29
 
 - **Breaking change**: `Tewmoji.parse` `img_attr` option changed to `img_attrs` [#16](https://github.com/jollygoodcode/twemoji/pull/16)

--- a/lib/twemoji.rb
+++ b/lib/twemoji.rb
@@ -164,7 +164,7 @@ module Twemoji
     # @return [Nokogiri::HTML::DocumentFragment] Parsed document.
     # @private
     def self.parse_document(doc)
-      doc.search('text()').each do |node|
+      doc.xpath('.//text() | text()').each do |node|
         content = node.to_html
         next if !content.include?(":")
         next if has_ancestor?(node, %w(pre code tt))

--- a/twemoji.gemspec
+++ b/twemoji.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = %w(lib)
 
-  spec.add_dependency "nokogiri", [">= 1.4", "<= 1.6.5"]
+  spec.add_dependency "nokogiri", "~> 1.6.2"
 end


### PR DESCRIPTION
Some ruby / rails projects already using Nokogiri 1.6.6.x, our version constraint is too narrow for them to use twemoji.

Nokogiri 1.6.1 has security issues, so let's start with Nokogiri 1.6.2. [Source](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc#162--2014-05-12)

- [ ] Cut two new releases: 2.0.1 and 1.1.1
- [ ] CHANGELOG