### PR TITLE
Fix render unicode method

### DIFF
--- a/lib/twemoji.rb
+++ b/lib/twemoji.rb
@@ -84,8 +84,9 @@ module Twemoji
   # @param text_or_code [String] Emoji text or code to render as unicode.
   # @return [String] Emoji UTF-8 Text.
   def self.render_unicode(text_or_code)
-    text_or_code = find_by_text(text_or_code) if text_or_code[0] == ":"
-    [text_or_code.hex].pack("U")
+    text_or_code = find_by_text(text_or_code) if text_or_code[0] == ?:
+    unicodes = text_or_code.split(?-)
+    unicodes.map(&:hex).pack(?U*unicodes.size)
   end
 
   # Parse string, replace emoji text with image.

--- a/test/twemoji_test.rb
+++ b/test/twemoji_test.rb
@@ -68,6 +68,14 @@ class TwemojiTest < Minitest::Test
     assert_equal ":flag-es:", Twemoji.find_by_unicode("🇪🇸")
   end
 
+  def test_render_unicode_country_flag
+    assert_equal "🇪🇸", Twemoji.render_unicode(":flag-es:")
+  end
+
+  def test_render_unicode_country_flag
+    assert_equal "🇪🇸", Twemoji.render_unicode("1f1ea-1f1f8")
+  end
+
   def test_find_by_escaped_unicode
     assert_equal ":heart_eyes:", Twemoji.find_by_unicode("\u{1f60d}")
   end

--- a/test/twemoji_test.rb
+++ b/test/twemoji_test.rb
@@ -156,6 +156,12 @@ class TwemojiTest < Minitest::Test
     end
   end
 
+  def test_parse_flag_img_alt
+    expected = %(<img draggable=\"false\" title=\":flag-sg:\" alt=\"🇸🇬\" src=\"https://twemoji.maxcdn.com/2/svg/1f1f8-1f1ec.svg\" class=\"emoji\">)
+
+    assert_equal expected, Twemoji.parse(":flag-sg:")
+  end
+
   def test_emoji_pattern
     assert_kind_of Regexp, Twemoji.emoji_pattern
   end


### PR DESCRIPTION
- `img` `alt` attribute now will render correctly