### PR TITLE
Fix handling codepoint less than 0x1000

### DIFF
--- a/lib/twemoji.rb
+++ b/lib/twemoji.rb
@@ -70,7 +70,7 @@ module Twemoji
   # @param raw [String] Emoji raw unicode to find text.
   # @return [String] Emoji Text.
   def self.find_by_unicode(raw)
-    invert_codes[raw.split("").map { |r| "%4.4x" % r.ord }.join("-")]
+    invert_codes[raw.split("").map { |r| "%x" % r.ord }.join("-")]
   end
 
   # Render raw emoji unicode from emoji text or emoji code.

--- a/test/twemoji_test.rb
+++ b/test/twemoji_test.rb
@@ -64,6 +64,10 @@ class TwemojiTest < Minitest::Test
     assert_equal ":heart_eyes:", Twemoji.find_by_unicode("😍")
   end
 
+  def test_find_by_unicode_copyright
+    assert_equal ":copyright:", Twemoji.find_by_unicode("©")
+  end
+
   def test_find_by_unicode_country_flag
     assert_equal ":flag-es:", Twemoji.find_by_unicode("🇪🇸")
   end


### PR DESCRIPTION
`Twemoji::CODES` doesn't have zero-padded codepoints.
So the following code did not work.
```ruby
Twemoji.find_by(unicode: '©') # '©' is 0x0023
```
Either `Twemoji::CODES` or decoding method should be modified.