### PR TITLE
Dependency Nokogiri >= 1.6

### DIFF
--- a/twemoji.gemspec
+++ b/twemoji.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "nokogiri", "~> 1.6.2"
+  spec.add_dependency "nokogiri", "~> 1.6"
 end


### PR DESCRIPTION
Because Nokogiri 1.7.x has fixed Ruby 2.4 warnings.

@JuanitoFatas 
