### PR TITLE
Fix strange naming of kiss emoji (left to do)

### DIFF
--- a/lib/twemoji/data/emoji-unicode-png.yml
+++ b/lib/twemoji/data/emoji-unicode-png.yml
@@ -806,7 +806,7 @@
 ":woman-woman-girl-girl:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-1f469-200d-1f467-200d-1f467.png
 ":woman-heart-man:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-2764-fe0f-200d-1f468.png
 ":woman-heart-woman:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-2764-fe0f-200d-1f469.png
-":kiss::man:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-2764-fe0f-200d-1f48b-200d-1f468.png
+":woman-kiss-man:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-2764-fe0f-200d-1f48b-200d-1f468.png
 ":woman-kiss-woman:": https://twemoji.maxcdn.com/2/72x72/1f469-200d-2764-fe0f-200d-1f48b-200d-1f469.png
 ":family:": https://twemoji.maxcdn.com/2/72x72/1f46a.png
 ":couple:": https://twemoji.maxcdn.com/2/72x72/1f46b.png

--- a/lib/twemoji/data/emoji-unicode-svg.yml
+++ b/lib/twemoji/data/emoji-unicode-svg.yml
@@ -806,7 +806,7 @@
 ":woman-woman-girl-girl:": https://twemoji.maxcdn.com/2/svg/1f469-200d-1f469-200d-1f467-200d-1f467.svg
 ":woman-heart-man:": https://twemoji.maxcdn.com/2/svg/1f469-200d-2764-fe0f-200d-1f468.svg
 ":woman-heart-woman:": https://twemoji.maxcdn.com/2/svg/1f469-200d-2764-fe0f-200d-1f469.svg
-":kiss::man:": https://twemoji.maxcdn.com/2/svg/1f469-200d-2764-fe0f-200d-1f48b-200d-1f468.svg
+":woman-kiss-man:": https://twemoji.maxcdn.com/2/svg/1f469-200d-2764-fe0f-200d-1f48b-200d-1f468.svg
 ":woman-kiss-woman:": https://twemoji.maxcdn.com/2/svg/1f469-200d-2764-fe0f-200d-1f48b-200d-1f469.svg
 ":family:": https://twemoji.maxcdn.com/2/svg/1f46a.svg
 ":couple:": https://twemoji.maxcdn.com/2/svg/1f46b.svg


### PR DESCRIPTION
"kiss: woman, man" emoji's name should be ":woman-kiss-man:".
But some files were written ":kiss::man:".
I fixed this problem before(#32), but some files were unfixed.
I fix emoji-unicode-{png,svg}.yml.