### PR TITLE
Fix wrong emoji code

### DIFF
--- a/lib/twemoji/map.rb
+++ b/lib/twemoji/map.rb
@@ -823,7 +823,7 @@ module Twemoji
     ":woman::skin-tone-3:" => "1f469-1f3fc",
     ":woman::skin-tone-4:" => "1f469-1f3fd",
     ":woman::skin-tone-5:" => "1f469-1f3fe",
-    ":woman::skin-tone-6" => "1f469-1f3ff",
+    ":woman::skin-tone-6:" => "1f469-1f3ff",
     ":woman:" => "1f469",
     ":woman-woman-boy:" => "1f469-200d-1f469-200d-1f466",
     ":woman-woman-boy-boy:" => "1f469-200d-1f469-200d-1f466-200d-1f466",

--- a/lib/twemoji/png.rb
+++ b/lib/twemoji/png.rb
@@ -804,7 +804,7 @@ module Twemoji
     ":woman::skin-tone-3:" => "https://twemoji.maxcdn.com/2/72x72/1f469-1f3fc.png",
     ":woman::skin-tone-4:" => "https://twemoji.maxcdn.com/2/72x72/1f469-1f3fd.png",
     ":woman::skin-tone-5:" => "https://twemoji.maxcdn.com/2/72x72/1f469-1f3fe.png",
-    ":woman::skin-tone-6" => "https://twemoji.maxcdn.com/2/72x72/1f469-1f3ff.png",
+    ":woman::skin-tone-6:" => "https://twemoji.maxcdn.com/2/72x72/1f469-1f3ff.png",
     ":woman:" => "https://twemoji.maxcdn.com/2/72x72/1f469.png",
     ":woman-woman-boy:" => "https://twemoji.maxcdn.com/2/72x72/1f469-200d-1f469-200d-1f466.png",
     ":woman-woman-boy-boy:" => "https://twemoji.maxcdn.com/2/72x72/1f469-200d-1f469-200d-1f466-200d-1f466.png",

--- a/lib/twemoji/svg.rb
+++ b/lib/twemoji/svg.rb
@@ -804,7 +804,7 @@ module Twemoji
     ":woman::skin-tone-3:" => "https://twemoji.maxcdn.com/2/svg/1f469-1f3fc.svg",
     ":woman::skin-tone-4:" => "https://twemoji.maxcdn.com/2/svg/1f469-1f3fd.svg",
     ":woman::skin-tone-5:" => "https://twemoji.maxcdn.com/2/svg/1f469-1f3fe.svg",
-    ":woman::skin-tone-6" => "https://twemoji.maxcdn.com/2/svg/1f469-1f3ff.svg",
+    ":woman::skin-tone-6:" => "https://twemoji.maxcdn.com/2/svg/1f469-1f3ff.svg",
     ":woman:" => "https://twemoji.maxcdn.com/2/svg/1f469.svg",
     ":woman-woman-boy:" => "https://twemoji.maxcdn.com/2/svg/1f469-200d-1f469-200d-1f466.svg",
     ":woman-woman-boy-boy:" => "https://twemoji.maxcdn.com/2/svg/1f469-200d-1f469-200d-1f466-200d-1f466.svg",


### PR DESCRIPTION
In lib/twemoji/{map,png,svg}.rb,
a colon was missing in :woman::skin-tone-6: emoji's code as below.

```
:woman::skin-tone-6
```

This colon is supplemented.