### PR TITLE
[WIP] Fix dealing presentation selector #46

### DIFF
--- a/lib/twemoji.rb
+++ b/lib/twemoji.rb
@@ -58,7 +58,7 @@ module Twemoji
   # @param code [String] Emoji code to find text.
   # @return [String] Emoji Text.
   def self.find_by_code(code)
-    invert_codes[must_str(code)]
+    invert_codes[must_str(code).gsub(/(-fe0e|-fe0f)/, '')]
   end
 
   # Find emoji text by raw emoji unicode.
@@ -70,7 +70,7 @@ module Twemoji
   # @param raw [String] Emoji raw unicode to find text.
   # @return [String] Emoji Text.
   def self.find_by_unicode(raw)
-    invert_codes[unicode_to_str(raw)]
+    invert_codes[unicode_to_str(raw).gsub(/(-fe0e|-fe0f)/, '')]
   end
 
   # Render raw emoji unicode from emoji text or emoji code.

--- a/lib/twemoji/data/emoji-unicode.yml
+++ b/lib/twemoji/data/emoji-unicode.yml
@@ -791,8 +791,8 @@
 ":man-woman-girl:": 1f468-200d-1f469-200d-1f467
 ":man-woman-girl-boy:": 1f468-200d-1f469-200d-1f467-200d-1f466
 ":man-woman-girl-girl:": 1f468-200d-1f469-200d-1f467-200d-1f467
-":man-heart-man:": 1f468-200d-2764-fe0f-200d-1f468
-":man-kiss-man:": 1f468-200d-2764-fe0f-200d-1f48b-200d-1f468
+":man-heart-man:": 1f468-200d-2764-200d-1f468
+":man-kiss-man:": 1f468-200d-2764-200d-1f48b-200d-1f468
 ":woman::skin-tone-2:": 1f469-1f3fb
 ":woman::skin-tone-3:": 1f469-1f3fc
 ":woman::skin-tone-4:": 1f469-1f3fd
@@ -804,10 +804,10 @@
 ":woman-woman-girl:": 1f469-200d-1f469-200d-1f467
 ":woman-woman-girl-boy:": 1f469-200d-1f469-200d-1f467-200d-1f466
 ":woman-woman-girl-girl:": 1f469-200d-1f469-200d-1f467-200d-1f467
-":woman-heart-man:": 1f469-200d-2764-fe0f-200d-1f468
-":woman-heart-woman:": 1f469-200d-2764-fe0f-200d-1f469
-":woman-kiss-man:": 1f469-200d-2764-fe0f-200d-1f48b-200d-1f468
-":woman-kiss-woman:": 1f469-200d-2764-fe0f-200d-1f48b-200d-1f469
+":woman-heart-man:": 1f469-200d-2764-200d-1f468
+":woman-heart-woman:": 1f469-200d-2764-200d-1f469
+":woman-kiss-man:": 1f469-200d-2764-200d-1f48b-200d-1f468
+":woman-kiss-woman:": 1f469-200d-2764-200d-1f48b-200d-1f469
 ":family:": 1f46a
 ":couple:": 1f46b
 ":two_men_holding_hands:": 1f46c

--- a/test/twemoji_test.rb
+++ b/test/twemoji_test.rb
@@ -83,6 +83,14 @@ class TwemojiTest < Minitest::Test
     assert_equal ":heart_eyes:", Twemoji.find_by_unicode("\u{1f60d}")
   end
 
+  def test_find_by_code_including_emoji_presentation_selector
+    assert_equal ":eye::left_speech_bubble:", Twemoji.find_by_code("1f441-fe0f-200d-1f5e8-fe0f")
+  end
+
+  def test_find_by_unicode_including_emoji_presentation_selector
+    assert_equal ":eye::left_speech_bubble:", Twemoji.find_by_unicode("\u{1f441}\u{fe0f}\u{200d}\u{1f5e8}\u{fe0f}")
+  end
+
   def test_parse_plus_one
     expected = %(<img draggable="false" title=":+1:" alt="👍" src="https://twemoji.maxcdn.com/2/svg/1f44d.svg" class="emoji">)
 
@@ -211,7 +219,7 @@ class TwemojiTest < Minitest::Test
     expected = %(<p><img draggable="false" title=":cookie:" alt="🍪" src="https://twemoji.maxcdn.com/2/svg/1f36a.svg" class="emoji" aria-label="emoji: cookie"><img draggable="false" title=":birthday:" alt="🎂" src="https://twemoji.maxcdn.com/2/svg/1f382.svg" class="emoji" aria-label="emoji: birthday"></p>)
     aria_label = ->(name) { 'emoji: ' + name.gsub(":", '') }
     assert_equal expected, Twemoji.parse(Nokogiri::HTML::DocumentFragment.parse("<p>🍪🎂</p>"), img_attrs: {'aria-label'=> aria_label } ).to_html
-  end  
+  end
 
   def test_parse_by_unicode_multiple_mix_codepoint_name_html
     expected = %(<p><img draggable="false" title=":cookie:" alt="🍪" src="https://twemoji.maxcdn.com/2/svg/1f36a.svg" class="emoji" aria-label="emoji: cookie"><img draggable="false" title=":birthday:" alt="🎂" src="https://twemoji.maxcdn.com/2/svg/1f382.svg" class="emoji" aria-label="emoji: birthday"></p>)
@@ -230,5 +238,4 @@ class TwemojiTest < Minitest::Test
     aria_label = ->(name) { 'emoji: ' + name.gsub(":", '') }
     assert_equal expected, Twemoji.parse(":cookie::birthday:", img_attrs: {'aria-label'=> aria_label } )
   end 
-
 end


### PR DESCRIPTION
Emoji and text presentation selector used to request an emoji or text presentation for an emoji charactor.

If an emoji presentation character (EPC) is given,
the emoji should be replaced by corresponding image.
If a text presentation character (TPC) is given,
the emoji shouldn't be replaced by it.
And if an emoji zwj sequence includes TPC, the sequence will be several emojis[1][evsn].
If an EPC or TPC is not given,
the emoji's expression is determined by the value of its emoji property "Emoji_Presentation".

However, I don't think it makes sense to deal with the Emoji_Presentation property.
For example,
an emoji "🈁" (U+1F201) is `Emoji_Presentation=Yes`,
but "🈂" (U+1F202) is `Emoji_Presentation=No`[2][emoji-data].
Besides, though many other food emoji are `Emoji_Presentation=Yes`,
"🌶" is `Emoji_Presentation=No`.
Do you think this has a meaning?

It's difficult to handle about presentation,
so I think that it is better to ignore emoji and text presentation characters.
And I implemented it.

What do you think?
Thankyou.

[evsn]:http://unicode.org/reports/tr51/#Emoji_Variation_Selector_Notes
[emoji-data]:http://unicode.org/Public/emoji/5.0/emoji-data.txt